### PR TITLE
build: TLS access with ingress

### DIFF
--- a/manifests/ingress.yaml
+++ b/manifests/ingress.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: app
+  namespace: 6ow3idgirl
+  annotations:
+    cert-manager.io/issuer: "letsencrypt"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - 6ow3idgirl.com
+      # cert-manager automatically generate secret
+      secretName: tls-cert
+  rules:
+    - host: 6ow3idgirl.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: express
+                port:
+                  number: 80

--- a/manifests/issuer.yaml
+++ b/manifests/issuer.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: letsencrypt
+  namespace: 6ow3idgirl
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: 'hrykwkbys1024@gmail.com'
+    # cert-manager automatically generate secret
+    privateKeySecretRef:
+      name: ca-letsencrypt
+    solvers:
+      - http01:
+          ingress:
+            class: nginx


### PR DESCRIPTION
# Issue link
closes: #51 

# What does this PR do?
- added issuer resource of Let's Encrypt, whose ACME challenge method for custom domain is HTTP-01
- added ingress resource associated to cert-manager issuer

# (Optional) Additional Contexts for PR Reviews
- Secret resources, both for TLS termination to application access and for HTTP-01 domain validation, have already created automatically when we create issuer/ingress resources in GKE cluster after applying manifests.