### PR TITLE
ci: added scheduled workflow to cleanup staled image.

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -1,0 +1,22 @@
+name: Image Cleanup
+
+on:
+  schedule:
+    # Runs on 19:00 JST every day, note that cron syntax applied as UTC
+    - cron: '0 10 * * *'
+  workflow_dispatch:
+
+jobs:
+  clean-ghcr:
+    name: Delete old unused container images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete old images
+        uses: snok/container-retention-policy@v2
+        with:
+          image-names: 6ow3idgirl
+          cut-off: 1 days ago JST
+          # Keep 1 image within 1 days ago
+          keep-at-least: 3
+          account-type: personal
+          token: ${{ secrets.PAT_PACKAGE_CLEANUP }}


### PR DESCRIPTION
# Issue link
relates: #49 

# What does this PR do?
- added schedule workflow using `snok/container-retention-policy@v2`

# (Optional) Additional Contexts for PR Reviews
- We have to wait at least a day for applying changes, so the issue will be still opened until validation will be completed
- For deletion of packages, we have to use GitHub PAT as permission, so we have added repository secret named `PAT_PACKAGE_CLEANUP` whose scope is `package:delete` 